### PR TITLE
Catalog builder updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
   - conda create -n psl-dev python=$TRAVIS_PYTHON_VERSION pip
+  - source activate psl-dev
   - cd Tools/Catalog-Builder
   - pip install -r requirements.txt
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+dist: xenial
+language: python
+python:
+  - "3.6"
+  - "3.7"
+
+# command to install dependencies
+install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  - conda create -n psl-dev python=$TRAVIS_PYTHON_VERSION pip
+  - cd Tools/Catalog-Builder
+  - pip install -r requirements.txt
+  - pip install -e .
+
+# command to run tests
+script:
+- cd Tools/Catalog-Builder/catalog_builder && pytest tests/ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 
 # command to run tests
 script:
-- cd Tools/Catalog-Builder/catalog_builder && pytest tests/ -v
+- cd catalog_builder && pytest tests/ -v

--- a/Tools/Catalog-Builder/README.md
+++ b/Tools/Catalog-Builder/README.md
@@ -40,8 +40,6 @@ How to add projects to the catalog
 
 2. Create a `PSL_catalog.json` file according to the schema below.
 
-    Catalog configuration file: `PSL_catalog.json`
-    -----------------------------------------------
     The purpose of the project's `PSL_catalog.json` file is to help the catalog builder locate information about the project. This information will be stored in the PSL catalog and rendered on the project's PSL page. The basic layout of this file looks like this:
 
     ```

--- a/Tools/Catalog-Builder/README.md
+++ b/Tools/Catalog-Builder/README.md
@@ -3,105 +3,110 @@ This directory will contain the Catalog-Builder, which will automatically genera
 How to run this package
 ------------------------
 1. Set-up environment
-```
-cd Tools/Catalog-Builder
-pip install -r requirements.txt
-pip install -e .
-```
+
+    ```
+    cd Tools/Catalog-Builder
+    conda create -n psl-dev pip
+    conda activate psl-dev
+    pip install -r requirements.txt
+    pip install -e .
+    ```
+
+    Note: Try using "source" instead of "conda" if the conda commands fail.
+
+2. Run tests to ensure that everything is set up correctly:
+    ```
+    py.test tests -v
+    ```
 
 2. Run package
 
-`python catalog_builder/catalog.py`
+    `python catalog_builder/catalog.py`
 
-The results are written to the `PSL/Catalog` directory. The `Catalog/index.html` file contains a list of the projects and an overview of what they do. A card for each project is written to the `PSL/Catalog` directory and named according to the project's name. These files can be viewed locally by opening them in the web browser. Most browsers have a "File" option in the menu bar that can be used to open a local HTML file.
-
-How to run tests
-------------------
-
-`py.test tests/test_catalog.py`
+    The results are written to the `PSL/Catalog` directory. The `Catalog/index.html` file contains a list of the projects and an overview of what they do. A card for each project is written to the `PSL/Catalog` directory and named according to the project's name. These files can be viewed locally by opening them in the web browser. Most browsers have a "File" option in the menu bar that can be used to open a local HTML file.
 
 How to add projects to the catalog
 ---------------------------------
 1. Append the project to the [`register.json`](../../Catalog/register.json) file with the format:
-```
-{
-    "org": the project's github organization name,
-    "repo": the project's github repository name,
-    "branch": master
-}
-```
+    ```
+    {
+        "org": the project's github organization name,
+        "repo": the project's github repository name,
+        "branch": "master"
+    }
+    ```
 
-Note: We can add support for other version control repositories upon request.
+    Note: We can add support for other version control repositories upon request.
 
-2. Create a `PSL_catalog.json` file according to the schema below
+2. Create a `PSL_catalog.json` file according to the schema below.
 
-Catalog configuration file: `PSL_catalog.json`
------------------------------------------------
-The purpose of the project's `PSL_catalog.json` file is to help the catalog builder locate information about the project. This information will be stored in the PSL catalog and rendered on the project's PSL page. The basic layout of this file looks like this:
+    Catalog configuration file: `PSL_catalog.json`
+    -----------------------------------------------
+    The purpose of the project's `PSL_catalog.json` file is to help the catalog builder locate information about the project. This information will be stored in the PSL catalog and rendered on the project's PSL page. The basic layout of this file looks like this:
 
-```
-{
-    'project_one_line': {
-        'start_header': header signalling section start for pulling data
-        'end_header': header signalling section to stop pulling data
-        'type': 'github_file' or 'html', more can be added as necessary
-        'data': null or HTML string to be displayed in section
-        'source': information required to construct location of data
-    },
-    'project_overview' : {
-        'start_header': ...
-        'end_header': ...
-        'type': ...
-        'data': ...
-        'source': ...
-    },
-    # other project attributes are listed out here
-    ...
-}
-```
+    ```
+    {
+        'project_one_line': {
+            'start_header': header signalling section start for pulling data
+            'end_header': header signalling section to stop pulling data
+            'type': 'github_file' or 'html', more can be added as necessary
+            'data': null or HTML string to be displayed in section
+            'source': information required to construct location of data
+        },
+        'project_overview' : {
+            'start_header': ...
+            'end_header': ...
+            'type': ...
+            'data': ...
+            'source': ...
+        },
+        # other project attributes are listed out here
+        ...
+    }
+    ```
 
-Currently, data for each project attribute can be specified on github or directly in the "data" attribute of the `PSL_catalog.json` file. If the data is specified on github, the attribute "type" should be set to "github_file." If the data is set directly in the `PSL_catalog.json` file, the "type" should be set to "html." Here are more in depth descriptions for how to fill out the catalog in both of these cases:
+    Currently, data for each project attribute can be specified on github or directly in the "data" attribute of the `PSL_catalog.json` file. If the data is specified on github, the attribute "type" should be set to "github_file." If the data is set directly in the `PSL_catalog.json` file, the "type" should be set to "html." Here are more in depth descriptions for how to fill out the catalog in both of these cases:
 
-- "type" is "github_file"
-  - "source" is the name of the file in the project's GitHub repository. It should be a markdown file.
-  - "start_header" and "end_header" are the headers in the markdown file. Data between those headers will be parsed and rendered to HTML.
-    - If neither header is specified, the entire document will be parsed.
-    - If "start_header" is speecified and "end_header" is not specified, then data from "start_header" to the end of the file will be parsed.
-    - If "end_header" is specified and "start_header" is not specified, then data from the beginning of the file to "end_header" is parsed.
-    - If the parser cannot find these headers, then an error will be raised.
-  - "data" is ignored in this case.
-- "type" is "html"
-  - The "data" attribute should be either a plain-text string or an HTML string.
-  - "source" can optionally be set to a webpage where this data can be verified or more information about it can be found.
-  - "start_header" and "end_header" are ignored in this case.
+    - "type" is "github_file"
+        - "source" is the name of the file in the project's GitHub repository. It should be a markdown file.
+        - "start_header" and "end_header" are the headers in the markdown file. Data between those headers will be parsed and rendered to HTML.
+            - If neither header is specified, the entire document will be parsed.
+            - If "start_header" is speecified and "end_header" is not specified, then data from "start_header" to the end of the file will be parsed.
+            - If "end_header" is specified and "start_header" is not specified, then data from the beginning of the file to "end_header" is parsed.
+            - If the parser cannot find these headers, then an error will be raised.
+        - "data" is ignored in this case.
+    - "type" is "html"
+        - The "data" attribute should be either a plain-text string or an HTML string.
+        - "source" can optionally be set to a webpage where this data can be verified or more information about it can be found.
+        - "start_header" and "end_header" are ignored in this case.
 
-Attributes that MUST be included:
-  - `project_one_line`: NA
-  - `project_overview`: Project Overview,
-  - `key_features`: Key Features
-  - `citation`: Citation,
-  - `license`: License,
-  - `user_documentation`: User Documentation,
-  - `user_changelog_recent`: User Changelog Recent,
-  - `user_changelog`: User Changelog,
-  - `dev_changelog`: Developer Changelog,
-  - `disclaimer`: Disclaimer,
-  - `user_case_studies`: User Case Studies,
-  - `project_roadmap`: Project Roadmap,
-  - `contributor_overview`: Contributor Overview,
-  - `contributor_guide`: Contributor Guide,
-  - `governance_overview`: Governance Overview,
-  - `public_funding`: Public Funding,
-  - `link_to_webapp`: Link to webapp,
-  - `public_issue_tracker`: Public Issue Tracker,
-  - `public_qanda`: Public Q & A
-  - `core_maintainers`: Core Maintainers
-  - `unit_test`: Unit Tests
-  - `integration_test`: Integration Tests
+    Attributes that MUST be included:
+    - `project_one_line`: NA
+    - `project_overview`: Project Overview,
+    - `key_features`: Key Features
+    - `citation`: Citation,
+    - `license`: License,
+    - `user_documentation`: User Documentation,
+    - `user_changelog_recent`: User Changelog Recent,
+    - `user_changelog`: User Changelog,
+    - `dev_changelog`: Developer Changelog,
+    - `disclaimer`: Disclaimer,
+    - `user_case_studies`: User Case Studies,
+    - `project_roadmap`: Project Roadmap,
+    - `contributor_overview`: Contributor Overview,
+    - `contributor_guide`: Contributor Guide,
+    - `governance_overview`: Governance Overview,
+    - `public_funding`: Public Funding,
+    - `link_to_webapp`: Link to webapp,
+    - `public_issue_tracker`: Public Issue Tracker,
+    - `public_qanda`: Public Q & A
+    - `core_maintainers`: Core Maintainers
+    - `unit_test`: Unit Tests
+    - `integration_test`: Integration Tests
 
-See examples here:
-- [`OG-USA/PSL_catalog.json`][]
-- [`Tax-Calculator/PSL_catalog.json`][]
+    See examples here:
+    - [`OG-USA/PSL_catalog.json`][]
+    - [`Tax-Calculator/PSL_catalog.json`][]
 
 
 

--- a/Tools/Catalog-Builder/catalog_builder/catalog.py
+++ b/Tools/Catalog-Builder/catalog_builder/catalog.py
@@ -228,7 +228,7 @@ if __name__ == "__main__":
                             "the GitHub API."),
                         default=False,
                         action="store_true")
-    parser.add_argument("--build_one",
+    parser.add_argument("--build-one",
                         help=("Only build the catalog with the specified "
                               "project. This is helpful when you want to "
                               "run the catalog builder many times for the same "

--- a/Tools/Catalog-Builder/catalog_builder/catalog.py
+++ b/Tools/Catalog-Builder/catalog_builder/catalog.py
@@ -5,6 +5,9 @@ from collections import defaultdict
 
 from catalog_builder import utils
 
+class ProjectDoesNotExist(Exception):
+    pass
+
 class CatalogBuilder:
     """
     Receives list of projects and an optional directory indicating where to look
@@ -71,7 +74,7 @@ class CatalogBuilder:
     CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
 
     def __init__(self, projects=None, index_dir=None, card_dir=None,
-                 develop=False):
+                 develop=False, build_one=None):
         if projects is None:
             p = os.path.join(
                 self.CURRENT_PATH, "../register.json"
@@ -92,6 +95,19 @@ class CatalogBuilder:
         self.catalog = defaultdict(dict)
         self.repos = {}
         self.develop = develop
+        if build_one is not None:
+            success = False
+            for project in self.projects:
+                if project["repo"] == build_one:
+                   self.projects = [project]
+                   success = True
+                   break
+            if not success:
+                raise ProjectDoesNotExist(
+                    ("{0} is not in register.json or "
+                     "projects if provided.").format(build_one)
+                )
+
 
     def load_catalog(self):
         """
@@ -202,18 +218,26 @@ class CatalogBuilder:
         return cat_json
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--develop",
-                    help=("Optional argument indicating whether or not the "
-                          "CatalogBuilder package is being developed. "
-                          "Including this flag causes the catalog to be "
-                          "created from catalog.json, rather than pinging "
-                          "the GitHub API"),
-                    default=False,
-                    action="store_true")
-args = parser.parse_args()
 if __name__ == "__main__":
-    cb = CatalogBuilder(develop=args.develop)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--develop",
+                        help=("Optional argument indicating whether or not the "
+                            "CatalogBuilder package is being developed. "
+                            "Including this flag causes the catalog to be "
+                            "created from catalog.json, rather than pinging "
+                            "the GitHub API."),
+                        default=False,
+                        action="store_true")
+    parser.add_argument("--build_one",
+                        help=("Only build the catalog with the specified "
+                              "project. This is helpful when you want to "
+                              "run the catalog builder many times for the same "
+                              "project. For example, you want to add a new "
+                              "project to the catalog and you are trying to "
+                              "tweak the appearance of its card and website."),
+                        default=None)
+    args = parser.parse_args()
+    cb = CatalogBuilder(develop=args.develop, project=args.build_one)
     cb.load_catalog()
     cb.write_pages()
     cb.dump_catalog(os.path.join(cb.card_dir, "catalog.json"))

--- a/Tools/Catalog-Builder/catalog_builder/tests/test_catalog.py
+++ b/Tools/Catalog-Builder/catalog_builder/tests/test_catalog.py
@@ -103,11 +103,20 @@ def test_catalog_write_html(cb):
 def test_catalog_dumps(cb):
     assert cb.dump_catalog()
 
+def test_catalog_one_project(cb):
+    projects = [
+        {"org": "noorg", "repo": "TestProject", "branch": "master"},
+        {"org": "someorg", "repo": "NewProject", "branch": "master"}
+    ]
+    cb = catalog.CatalogBuilder(
+        projects,
+        build_one="NewProject",
+    )
+    assert len(cb.projects) == 1
+    assert cb.projects[0]["repo"] == "NewProject"
 
-def test_catalog_on_real_data():
-    cb = catalog.CatalogBuilder()
-    # only do the first project
-    cb.projects = [cb.projects[0]]
-    cb.load_catalog()
-    cb.write_pages()
-    cb.dump_catalog()
+    with pytest.raises(catalog.ProjectDoesNotExist):
+        cb = catalog.CatalogBuilder(
+            projects,
+            build_one="does not exist",
+        )

--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -12,6 +12,9 @@ import re
 class SectionHeadersDoNotExist(Exception):
     pass
 
+class URLFormatError(Exception):
+    pass
+
 def pre_parser(text):
     """
     Convert Github-Flavored markdown to Python markdown
@@ -111,6 +114,12 @@ def _get_from_github_api(org, repo, branch, filename):
     Read data from github api. Ht to @andersonfrailey for decoding the response
     """
     # TODO: incorporate master branch
+    if "http" in filename:
+        raise URLFormatError(
+            "A URL was entered for a 'github_file' type attribute. "
+            "For more information, check out the catalog configuration "
+            "docs: Tools/Catalog-Builder/README.md"
+        )
     url = f"https://api.github.com/repos/{org}/{repo}/contents/{filename}?ref={branch}"
     response = requests.get(url)
     print(f"GET: {url} {response.status_code}")


### PR DESCRIPTION
This PR makes a series of updates to the catalog builder package:
- Throws an exception, `URLFormatError`,  if a user attempts to specify a URL as the "source" for a "github_file" type `PSL_catalog.json` attribute. "source" should be a filename.
- The `--build-one` keyword argument is added to the cli. This allows the user to run the catalog-builder for one project. This is helpful when someone is adding a project to the Catalog and is tweaking their `PSL_catalog.json` file and card/project page.
- Enables Travis CI for the catalog-builder tests.
- Re-formats the catalog builder README file.