### PR TITLE
Create council.md

### DIFF
--- a/Community/council.md
+++ b/Community/council.md
@@ -1,0 +1,25 @@
+# PSL Leadership Council, Version 1.0.0
+
+## Council
+
+| Member         | Represented Project        | Email                    |
+|----------------|----------------------------|--------------------------|
+| Jason DeBacker | Cost-of-Capital-Calculator | jason.debacker@gmail.com |
+| Henry Doupe    | ParamTools                 | henrymdoupe@gmail.com    |
+| Richard Evans  | OG-USA                     | rickecon@gmail.com       |
+| Martin Holmer  | Tax-Calculator             | martin.holmer@gmail.com  |
+| Matt Jensen    | PSLmodels/PSL              | matt.h.jensen@gmail.com  |
+
+
+
+## Bylaws 
+
+- At most one representative for each PSL cataloged project and PSLmodels/PSL. 
+- No one person may represent more than one project. 
+- Majoritarian decision-making with a quorum of half of the members or more. 
+- Projects may join PSL based on conformance to PSL criteria and mission, subject to a PSL leadership council vote in a private forum, such as a PSL leadership council conference call.
+- Substantive changes to the PSL criteria, mission, or other foundational texts are subject to a PSL leadership council vote in a public forum, such as a GitHub pull request to PSLmodels/PSL. 
+
+## Log 
+
+Version 1.0.0 ratified 20 March 2019 with members Henry Doupe, Jason DeBacker, Matthew Jensen, Richard Evans, and Martin Holmer present.


### PR DESCRIPTION
This PR adds documentation to the repo for the PSL leadership council. The names and emails of the council members will be referenced in a forthcoming PR to add a code of conduct. 

cc @martinholmer @jdebacker @rickecon @hdoupe 