### PR TITLE
add leadership council & code of conduct to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ If you would like to make a technical contribution to PSL, please review the [co
 
 You can reach PSL developers and users to discuss how to get started by opening an issue or joining the PSL Community [chat room](https://matrix.to/#/!oZnjlINzAXrgdzXEfZ:matrix.org).
 
+PSL is governed by a [leadership council](https://github.com/PSLmodels/PSL/blob/master/Community/council.md) of project representatives. 
+
+The PSL community is respectful, warm, and open to everyone. In order to ensure that the project remain that way for all participants, we have officially adopted the [NumFOCUS Code of Conduct](https://numfocus.org/code-of-conduct) as our own, with the exception that infractions should be reported to a PSL leadership council member. 
+


### PR DESCRIPTION
This PR adds the leadership council and a code of conduct to the readme. It should be merged *after* #107. 

Given that we did not discuss the code of conduct reporting standards explicitly in our recent council meeting, I ask that the leadership council please review this PR per our bylaws. Reviews and feedback from the rest of the community is also welcome. 

cc @martinholmer @jdebacker @rickecon @hdoupe 