### PR TITLE
Add Tax-Brain to PSL catalog

### DIFF
--- a/Catalog/Tax-Brain.html
+++ b/Catalog/Tax-Brain.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+    <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
+        <meta charset="utf-8">
+        <title>PSL Models</title>
+        <!-- include bootstrap -->
+        <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <style>
+        .jumbotron {
+            background-color: transparent !important;
+        }
+    </style>
+    <link rel="stylesheet" href="../CSS/page.css">
+    <body>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+            <div class="navbar-header">
+                <a href="../index.html" class="navbar-brand">Policy Simulation Library</a>
+            </div>
+            <ul class="navbar-nav">
+                <!-- TODO: Need better solution to relative path here -->
+                <li class="nav-item"><a href="index.html" class="nav-link">Catalog</a></li>
+                <li class="nav-item"><a href="../about.html" class="nav-link">About PSL</a></li>
+                <li class="nav-item"><a href="../Newsletter/archive.html" class="nav-link">Newsletter</a></li>
+            </ul>
+        </nav>
+
+        <div class="container">
+            <div class="jumbotron model-info">
+                <h1 class="display-4">Tax-Brain</h1>
+                <p class="lead"><p>Integrator package for multiple open source tax models</p></p>
+                <hr class="my-4">
+                
+                    
+                
+                    
+                        <h4> Project Overview</h4>
+                        <p><p>Tax-Brain makes it easy for users to simulate the US tax system by providing a single interface for multiple tax models. Currently, Tax-Brain interfaces with <a href="https://github.com/PSLmodels/Tax-Calculator">Tax-Calculator</a> and <a href="https://github.com/PSLmodels/Behavioral-Responses">Behavior-Response</a>. Additional models will be added in the near future to expand Tax-Brain's capabilities to include modeling business taxation and running dynamic general equilibrium simulations.</p> <p>To learn more about how Tax-Brain works, see <a href="https://github.com/PSLmodels/Tax-Brain/blob/master/DOC.md">this</a> document.</p> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                
+                    
+                        <h4> License</h4>
+                        <p><p>MIT</p> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/LICENSE.txt >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> User Documentation</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md">https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> User Changelog Recent</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/releases/latest">https://github.com/PSLmodels/Tax-Brain/releases/latest</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/RELEASES.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> User Changelog</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/releases">https://github.com/PSLmodels/Tax-Brain/releases</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/releases >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Developer Changelog</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/releases">https://github.com/PSLmodels/Tax-Brain/releases</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/releases >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Disclaimer</h4>
+                        <p><p>Tax-brain and it's underlying models are constantly being improved upon. For that reason, the results output by Tax-Brain may differ over time. It is strongly suggested that the user make note of which version of Tax-Brain, they are using when reporting their results.</p> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                
+                    
+                        <h4> Project Roadmap</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md">https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Core Maintainers</h4>
+                        <p><ul><li>Anderson Frailey</li></ul> </p>
+                        
+                    
+                
+                    
+                        <h4> Contributor Overview</h4>
+                        <p><p>Contributions to Tax-Brain are always welcome. To contribute, open a <a href="https://github.com/PSLmodels/Tax-Brain/pulls">pull request (PR)</a> with your changes and any associated tests. In this PR, please describe what your change does and link to any relevant issues and discussions.</p> <h5>Feature Requests</h5> <p>To request a feature, please open an <a href="https://github.com/PSLmodels/Tax-Brain/issues">issue</a> describing the desired feature and it's use cases.</p> <h5>Bug Reports</h5> <p>To report a bug in Tax-Brain, open an <a href="https://github.com/PSLmodels/Tax-Brain/issues">issue</a> describing the bug. Please include the code needed to reproduce the bug.</p> <h5>Developer Setup</h5> <p>Start by forking and cloning the Tax-Brain repo. Next, run the following commands in the terminal to create and activate the developer conda environment:</p> <p><code>bash cd Tax-Brain conda env create -f environment.yml conda activate taxbrain-dev</code></p> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Contributor Guide</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md">https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Unit Tests</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests">https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Integration Tests</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests">https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests</a> </p>
+                        
+                            <p><a href=https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests >[source]</a></p>
+                        
+                    
+                
+                    
+                
+                    
+                
+                    
+                        <h4> Link to webapp</h4>
+                        <p><a href="https://www.compmodels.com/PSLmodels/Tax-Brain/">Tax-Brain</a> </p>
+                        
+                    
+                
+                    
+                        <h4> Public Issue Tracker</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/issues">https://github.com/PSLmodels/Tax-Brain/issues</a> </p>
+                        
+                    
+                
+                    
+                        <h4> Public Q & A</h4>
+                        <p><a href="https://github.com/PSLmodels/Tax-Brain/issues">https://github.com/PSLmodels/Tax-Brain/issues</a> </p>
+                        
+                    
+                
+            </div>
+        </div>
+    </body>
+</html>

--- a/Catalog/catalog.json
+++ b/Catalog/catalog.json
@@ -375,6 +375,100 @@
             "value": "<a href=\"https://github.com/PSLmodels/ParamTools/tree/master/paramtools/tests\">https://github.com/PSLmodels/ParamTools/tree/master/paramtools/tests</a>"
         }
     },
+    "Tax-Brain": {
+        "name": {
+            "value": "Tax-Brain",
+            "source": ""
+        },
+        "project_one_line": {
+            "source": "https://github.com/PSLmodels/Tax-Brain",
+            "value": "<p>Integrator package for multiple open source tax models</p>"
+        },
+        "key_features": {
+            "source": null,
+            "value": null
+        },
+        "project_overview": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/README.md",
+            "value": "<p>Tax-Brain makes it easy for users to simulate the US tax system by providing a single interface for multiple tax models. Currently, Tax-Brain interfaces with <a href=\"https://github.com/PSLmodels/Tax-Calculator\">Tax-Calculator</a> and <a href=\"https://github.com/PSLmodels/Behavioral-Responses\">Behavior-Response</a>. Additional models will be added in the near future to expand Tax-Brain's capabilities to include modeling business taxation and running dynamic general equilibrium simulations.</p> <p>To learn more about how Tax-Brain works, see <a href=\"https://github.com/PSLmodels/Tax-Brain/blob/master/DOC.md\">this</a> document.</p>"
+        },
+        "citation": {
+            "source": null,
+            "value": null
+        },
+        "license": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/LICENSE.txt",
+            "value": "<p>MIT</p>"
+        },
+        "user_documentation": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md\">https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md</a>"
+        },
+        "user_changelog": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/releases",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/releases\">https://github.com/PSLmodels/Tax-Brain/releases</a>"
+        },
+        "user_changelog_recent": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/RELEASES.md",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/releases/latest\">https://github.com/PSLmodels/Tax-Brain/releases/latest</a>"
+        },
+        "dev_changelog": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/releases",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/releases\">https://github.com/PSLmodels/Tax-Brain/releases</a>"
+        },
+        "disclaimer": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/README.md",
+            "value": "<p>Tax-brain and it's underlying models are constantly being improved upon. For that reason, the results output by Tax-Brain may differ over time. It is strongly suggested that the user make note of which version of Tax-Brain, they are using when reporting their results.</p>"
+        },
+        "user_case_studies": {
+            "source": null,
+            "value": null
+        },
+        "project_roadmap": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md\">https://github.com/PSLmodels/Tax-Brain/blob/master/ROADMAP.md</a>"
+        },
+        "contributor_overview": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md",
+            "value": "<p>Contributions to Tax-Brain are always welcome. To contribute, open a <a href=\"https://github.com/PSLmodels/Tax-Brain/pulls\">pull request (PR)</a> with your changes and any associated tests. In this PR, please describe what your change does and link to any relevant issues and discussions.</p> <h5>Feature Requests</h5> <p>To request a feature, please open an <a href=\"https://github.com/PSLmodels/Tax-Brain/issues\">issue</a> describing the desired feature and it's use cases.</p> <h5>Bug Reports</h5> <p>To report a bug in Tax-Brain, open an <a href=\"https://github.com/PSLmodels/Tax-Brain/issues\">issue</a> describing the bug. Please include the code needed to reproduce the bug.</p> <h5>Developer Setup</h5> <p>Start by forking and cloning the Tax-Brain repo. Next, run the following commands in the terminal to create and activate the developer conda environment:</p> <p><code>bash cd Tax-Brain conda env create -f environment.yml conda activate taxbrain-dev</code></p>"
+        },
+        "contributor_guide": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md\">https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md</a>"
+        },
+        "governance_overview": {
+            "source": null,
+            "value": null
+        },
+        "public_funding": {
+            "source": null,
+            "value": null
+        },
+        "link_to_webapp": {
+            "source": null,
+            "value": "<a href=\"https://www.compmodels.com/PSLmodels/Tax-Brain/\">Tax-Brain</a>"
+        },
+        "public_issue_tracker": {
+            "source": null,
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/issues\">https://github.com/PSLmodels/Tax-Brain/issues</a>"
+        },
+        "public_qanda": {
+            "source": null,
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/issues\">https://github.com/PSLmodels/Tax-Brain/issues</a>"
+        },
+        "core_maintainers": {
+            "source": null,
+            "value": "<ul><li>Anderson Frailey</li></ul>"
+        },
+        "unit_test": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests\">https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests</a>"
+        },
+        "integration_test": {
+            "source": "https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests",
+            "value": "<a href=\"https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests\">https://github.com/PSLmodels/Tax-Brain/tree/master/taxbrain/tests</a>"
+        }
+    },
     "Tax-Calculator": {
         "name": {
             "value": "Tax-Calculator",

--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -172,6 +172,41 @@
                     </div>
                 
                     <div class="card">
+                        <div class="card-header" id="Tax-Brain-heading">
+                                <h2>
+                                    <a href="" style="color:inherit;" data-toggle="collapse" data-target="#Tax-Brain-collapse">Tax-Brain</a>
+                                    <div class="float-right">
+                                        <button
+                                            class="btn collapse-button"
+                                            type="button"
+                                            data-toggle="collapse"
+                                            data-target="#Tax-Brain-collapse"
+                                            aria-expanded="false"
+                                            aria-controls="Tax-Brain-collapse"
+                                            style="margin-left:20px;">
+                                            <i class="far fa-plus-square" style="size:.5x;"></i>
+                                        </button>
+                                    </div>
+                                </h2>
+                                <p>Integrator package for multiple open source tax models</p>
+                        </div>
+                        <div class="collapse" id="Tax-Brain-collapse" aria-labelledby="Tax-Brain-heading" data-parent="#accordionParent">
+                            <div class="container">
+                                <p><p>Tax-Brain makes it easy for users to simulate the US tax system by providing a single interface for multiple tax models. Currently, Tax-Brain interfaces with <a href="https://github.com/PSLmodels/Tax-Calculator">Tax-Calculator</a> and <a href="https://github.com/PSLmodels/Behavioral-Responses">Behavior-Response</a>. Additional models will be added in the near future to expand Tax-Brain's capabilities to include modeling business taxation and running dynamic general equilibrium simulations.</p> <p>To learn more about how Tax-Brain works, see <a href="https://github.com/PSLmodels/Tax-Brain/blob/master/DOC.md">this</a> document.</p></p>
+                                <h6>Maintainers</h6>
+                                <ul><li>Anderson Frailey</li></ul>
+                                <p><a href="Tax-Brain.html">Project Website</a></p>
+                                <p><a href="https://github.com/PSLmodels/Tax-Brain">Code Repository</a></p>
+                                <p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/USAGE.md">User documentation</a>
+</p><p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/CONTRIBUTING.md">Contributor documentation</a>
+</p><p><a href="https://github.com/PSLmodels/Tax-Brain/blob/master/RELEASES.md">Recent changes</a>
+</p><p><a href="https://www.compmodels.com/PSLmodels/Tax-Brain/">Link to webapp</a>
+</p>
+                            </div>
+                        </div>
+                    </div>
+                
+                    <div class="card">
                         <div class="card-header" id="Tax-Calculator-heading">
                                 <h2>
                                     <a href="" style="color:inherit;" data-toggle="collapse" data-target="#Tax-Calculator-collapse">Tax-Calculator</a>

--- a/Tools/Catalog-Builder/register.json
+++ b/Tools/Catalog-Builder/register.json
@@ -23,5 +23,10 @@
         "org": "PSLmodels",
         "repo": "ParamTools",
         "branch": "master"
+    },
+    {
+        "org": "PSLmodels",
+        "repo": "Tax-Brain",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
This PR adds Tax-Brain to the PSL catalog. Tax-Brain integrates multiple open source tax models in one package. More information on the project can be found on its [GitHub page](https://github.com/PSLmodels/Tax-Brain).

cc @hdoupe @MattHJensen @Peter-Metz 